### PR TITLE
Solve pather issue

### DIFF
--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.5")]
-[assembly: AssemblyFileVersion("1.0.0.5")]
+[assembly: AssemblyVersion("1.0.0.6")]
+[assembly: AssemblyFileVersion("1.0.0.6")]

--- a/Pug/Defs/Jobs.pug
+++ b/Pug/Defs/Jobs.pug
@@ -1,2 +1,3 @@
 +JobDef("TyphonMimicMultiply", "Typhon.JobDriver_MimicMultiply", "Multiplying")
 +JobDef("TyphonMimicBuilding", "Typhon.JobDriver_MimicBuilding", "Hiding")
++JobDef("TyphonAttackPawn", "Typhon.JobDriver_AttackPawn", "Attacking")

--- a/Pug/Defs/ThinkTrees.pug
+++ b/Pug/Defs/ThinkTrees.pug
@@ -6,7 +6,7 @@
   +ThinkNode("JobGiver_ReactToCloseMeleeThreat")
   +ThinkNode("ThinkNode_QueuedJob")
   +ThinkNode("Typhon.JobGiver_MimicMultiply")
-  +ThinkNode("Typhon.JobGiver_AttackNearbyPawns")
+  +ThinkNode("Typhon.JobGiver_AttackPawn")
   +ThinkNode("Typhon.JobGiver_MimicBuilding")
   +ThinkNode("ThinkNode_Tagger",{tagToGive:"Idle"})
     +ThinkNode("ThinkNode_ConditionalHerdAnimal")

--- a/Pug/News.pug
+++ b/Pug/News.pug
@@ -17,6 +17,17 @@ mixin UpdateNews(version, ...contents)
     content= content
 
 block defs
+  +UpdateNews("1.0.0.6",
+    ["Space-Ready Typhon!", [
+      "Minor patch to RaceProperties.IsFlesh which now causes Typhon to not be flesh! This will allow them to survive in the void of space!",
+      "Also, adjusted their minimum temperature comfiness to -101, just low enough to survive that cold environment with little issue.",
+      "No events yet to introduce typhon to spaceships, but if you've got ideas I'm ready for them."
+    ]],
+    ["Bugfix - Pather", [
+      "As an unintended side effect of the hivemind ability, mimics would read their own mind, and try to target untargettable pawns to attack.",
+      "Thanks to Pifilix, and especially CrazyOatmeal for the error output!"
+    ]]
+  )
   +UpdateNews("1.0.0.5",
     ["Mimic Building Comp filter", [
       "Mimics can no longer mmimic buildings with the comp \"CompCanBeDormant\", this solves them mimicing a dormant thing without a timer, making them immediately active, and causing strange situations."

--- a/Source/Jobs/JobDriver_AttackPawn.cs
+++ b/Source/Jobs/JobDriver_AttackPawn.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Verse.AI;
+
+namespace Typhon
+{
+    internal class JobDriver_AttackPawn : JobDriver_AttackMelee
+    {
+        public override void Notify_PatherFailed()
+        {
+            EndJobWith(JobCondition.ErroredPather);
+        }
+    }
+}

--- a/Source/Jobs/JobGiver_AttackPawn.cs
+++ b/Source/Jobs/JobGiver_AttackPawn.cs
@@ -4,17 +4,13 @@ using Verse.AI;
 
 namespace Typhon
 {
-    internal class JobGiver_AttackNearbyPawns : ThinkNode_JobGiver
+    internal class JobGiver_AttackPawn : ThinkNode_JobGiver
     {
         protected override Job TryGiveJob(Pawn pawn)
         {
             Pawn target = TyphonUtility.GetAttackableTarget(pawn, 5);
             if ((target == null) || !pawn.CanReserve(target, 4)) return null;
-            return new Job(JobDefOf.AttackMelee, target)
-            {
-                killIncappedTarget = true,
-                expiryInterval = Rand.Range(420, 900),
-            };
+            return JobMaker.MakeJob(TyphonDefOf.Job.TyphonAttackPawn, target);
         }
     }
 }

--- a/Source/Jobs/JobGiver_AttackPawn.cs
+++ b/Source/Jobs/JobGiver_AttackPawn.cs
@@ -10,7 +10,10 @@ namespace Typhon
         {
             Pawn target = TyphonUtility.GetAttackableTarget(pawn, 5);
             if ((target == null) || !pawn.CanReserve(target, 4)) return null;
-            return JobMaker.MakeJob(TyphonDefOf.Job.TyphonAttackPawn, target);
+            Job job = JobMaker.MakeJob(TyphonDefOf.Job.TyphonAttackPawn, target);
+            job.killIncappedTarget = true;
+            job.expiryInterval = Rand.Range(420, 900);
+            return job;
         }
     }
 }

--- a/Source/Utilities/TyphonDefOf.cs
+++ b/Source/Utilities/TyphonDefOf.cs
@@ -18,6 +18,7 @@ namespace Typhon.TyphonDefOf
     {
         public static Verse.JobDef TyphonMimicMultiply;
         public static Verse.JobDef TyphonMimicBuilding;
+        public static Verse.JobDef TyphonAttackPawn;
         static Job()
         {
             DefOfHelper.EnsureInitializedInCtor(typeof(JobDefOf));

--- a/Source/Utilities/TyphonUtility.cs
+++ b/Source/Utilities/TyphonUtility.cs
@@ -26,6 +26,7 @@ namespace Typhon
                 if (TyphonUtility.IsTyphon(thing))
                 {
                     Pawn typhon = thing as Pawn;
+                    if (pawn == typhon) continue;
                     Pawn target = typhon.LastAttackedTarget.Pawn;
                     if (target == null || target.Dead) continue;
                     return target;
@@ -54,6 +55,7 @@ namespace Typhon
                 || !(target.RaceProps.FleshType == FleshTypeDefOf.Normal)
                 || target.BodySize > 1.2
                 || !hunter.CanSee(target)
+                || !hunter.CanReach(target, PathEndMode.OnCell, Danger.Deadly)
             );
         }
     }

--- a/Typhon.csproj
+++ b/Typhon.csproj
@@ -43,9 +43,10 @@
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Source\Incidents\IncidentWorker_MimicCrash.cs" />
+    <Compile Include="Source\Jobs\JobDriver_AttackPawn.cs" />
     <Compile Include="Source\Jobs\JobDriver_MimicBuilding.cs" />
     <Compile Include="Source\Jobs\JobDriver_MimicMultiply.cs" />
-    <Compile Include="Source\Jobs\JobGiver_AttackNearbyPawns.cs" />
+    <Compile Include="Source\Jobs\JobGiver_AttackPawn.cs" />
     <Compile Include="Source\Jobs\JobGiver_MimicMultiply.cs" />
     <Compile Include="Source\Jobs\JobGiver_MimicBuilding.cs" />
     <Compile Include="Source\Mod.cs" />


### PR DESCRIPTION
Closes #41 

Wasn't an achtung issue after all, I am a dumb. AttackMelee seems to check a variable to attack doorswhen pathing failure happens, but I'm not setting that variable. Also, the hivemind feature could select itself to read its own mind, causing the jobgiver to give the same target (even if that target can't be reached, since it doesn't validate it)