### PR TITLE
Non-deterministic build and revision numbers

### DIFF
--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.7")]
+[assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyFileVersion("1.0.0.7")]

--- a/Typhon.csproj
+++ b/Typhon.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>Typhon</AssemblyName>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <Deterministic>true</Deterministic>
+    <Deterministic>false</Deterministic>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -106,7 +106,7 @@
   <PropertyGroup>
     <PostBuildEvent>cd $(ProjectDir)
 set list=About Defs Patches News
-(for %25%25a in (%25list%25) do ( 
+(for %25%25a in (%25list%25) do (
   mkdir %25%25a
   del /q %25%25a\*.xml
   call pug -s --pretty --extension xml --out %25%25a Pug\%25%25a.pug


### PR DESCRIPTION
As development goes on I should probably use version numbers properly, this'll make that slightly less annoying. Should be using build number rather than revisions, but oh well.