### PR TITLE
Nerf Typhon

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -40,6 +40,6 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
       with:
-        release_name: Automated Release ${{ github.run_id }}
-        tag_name: ${{ github.ref }}
+        release_name: Release \#${{ github.run_number }}
+        tag_name: release/${{ github.run_number }}
         asset_files: ${{env.mod_name}}.zip

--- a/Pug/Defs/BodyParts.pug
+++ b/Pug/Defs/BodyParts.pug
@@ -4,19 +4,19 @@
   bleedRate 0
 
 +BodyPartDef("TyphonThorax", "thorax")(ParentName="TyphonPart")
-  hitPoints 100
+  hitPoints 20
     
 +BodyPartDef("TyphonCore", "core")(ParentName="TyphonPart")
   +Tags("MovingLimbCore", "ManipulationLimbCore")
 
 +BodyPartDef("TyphonMimicLeg", "leg")(ParentName="TyphonPart")
   frostbiteVulnerability 0.01
-  hitPoints 20
+  hitPoints 10
   +Tags("MovingLimbCore", "ManipulationLimbCore")
   
 +BodyPartDef("TyphonTendril", "tendril")(ParentName="TyphonPart")
   frostbiteVulnerability 0.01
-  hitPoints 100
+  hitPoints 20
   +Tags("MovingLimbCore", "ManipulationLimbCore")
   
 +BodyPartDef("TyphonSpike", "spike")(ParentName="TyphonPart")

--- a/Pug/Defs/Incidents.pug
+++ b/Pug/Defs/Incidents.pug
@@ -7,7 +7,7 @@
   letterText A transport pod seems to be crashing nearby, with an anusual black creature, gripping it as it falls through the atmosphere.
   letterDef ThreatBig
   baseChance 7
-  minThreatPoints 100
+  minThreatPoints 500
 
 +IncidentDef("Typhon_Herd", "typhon herd")
   category ThreatBig
@@ -18,5 +18,5 @@
   letterText Typhon have wandered into the map.
   letterDef ThreatBig
   baseChance 6.5
-  minThreatPoints 200
+  minThreatPoints 700
   pointsScaleable true

--- a/Pug/Defs/Races/Mimic.pug
+++ b/Pug/Defs/Races/Mimic.pug
@@ -3,7 +3,7 @@
   receivesSignals true
   +Comps("Typhon.CompProperties.Hivemind", "Typhon.CompProperties.AttackOnDamage")
   statBases
-    MoveSpeed 10
+    MoveSpeed 8
   race
     body Typhon_Mimic
     thinkTreeMain Typhon_Thinktree_Mimic
@@ -14,21 +14,21 @@
   tools
     +Tool("Appendage")
       +Capacities("Blunt")
-      power 9
+      power 6
       cooldownTime .9
       linkedBodyPartsGroup FrontLeftLeg
       surpriseAttack
         +ExtraMeleeDamages([["Stun", 9]])
     +Tool("Appendage")
       +Capacities("Blunt")
-      power 9
+      power 6
       cooldownTime .9
       linkedBodyPartsGroup FrontRightLeg
       surpriseAttack
         +ExtraMeleeDamages([["Stun", 9]])
     +Tool("Body")
       +Capacities("Blunt")
-      power 5
+      power 4
       cooldownTime 2
       linkedBodyPartsGroup Torso
       ensureLinkedBodyPartsGroupAlwaysUsable true

--- a/Pug/News.pug
+++ b/Pug/News.pug
@@ -17,6 +17,12 @@ mixin UpdateNews(version, ...contents)
     content= content
 
 block defs
+  +UpdateNews("2.2.1.0", 
+    ["Nerf all Typhon", [
+      "Based on player feedback, weakened mimics, and set the event to require much more wealth.",
+      "I apologize for taking so long on this one! Been a busy time, working on Music Expanded Framework has taken a lot of my time and energy regarding RimWorld. Hopefully with the automated releases I'll have more time to make these adjustments"
+    ]]
+  )
   +UpdateNews("2.2.0.0", 
     ["Automated Releases!", [
       "This mod will now auto-update whenever I commit to the main branch. If you're seeing this, it worked!",

--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
         "name": "Typhon",
         "author": "Caaz",
         "description": "Adds Typhon from Prey (2015). For a full list of features, view the Workshop page!",
-        "version": "2.2.0.0",
+        "version": "2.2.1.0",
         "packageId": "caaz.typhon",
         "namespace": "Typhon",
         "assemblyName": "Typhon",


### PR DESCRIPTION
Typhon have too much health, deal too much damage, and show up too early to reasonably deal with them. 
All of these have been adjusted.